### PR TITLE
Fix URL parameter priority logic in useUserContext hook

### DIFF
--- a/src/hooks/useUserContext.ts
+++ b/src/hooks/useUserContext.ts
@@ -25,29 +25,24 @@ export function useUserContext(propsUserId?: string, propsProjectId?: string): U
 
     console.log(`[useUserContext] URL search params:`, window.location.search);
     console.log(`[useUserContext] URL userId: ${urlUserId}, projectId: ${urlProjectId}`);
+    console.log(`[useUserContext] Props userId: ${propsUserId}, projectId: ${propsProjectId}`);
+    console.log(`[useUserContext] Env userId: ${process.env.NEXT_PUBLIC_DEFAULT_USER_ID}, projectId: ${process.env.NEXT_PUBLIC_DEFAULT_PROJECT_ID}`);
 
-    let userId: string;
-    let projectId: string;
+    // Prioritize URL parameters first, then props, then environment variables
+    const userId = urlUserId || propsUserId || process.env.NEXT_PUBLIC_DEFAULT_USER_ID || 'demo-user';
+    const projectId = urlProjectId || propsProjectId || process.env.NEXT_PUBLIC_DEFAULT_PROJECT_ID || 'demo-project';
+
+    // Determine the primary source based on what was actually used
     let source: 'url' | 'env' | 'props';
-
-    if (urlUserId && urlProjectId) {
-      // Use URL parameters if both are present
-      userId = urlUserId;
-      projectId = urlProjectId;
+    if (urlUserId || urlProjectId) {
       source = 'url';
-    } else if (propsUserId && propsProjectId) {
-      // Use props if provided
-      userId = propsUserId;
-      projectId = propsProjectId;
+    } else if (propsUserId || propsProjectId) {
       source = 'props';
     } else {
-      // Fall back to environment variables or defaults
-      userId = process.env.NEXT_PUBLIC_DEFAULT_USER_ID || 'demo-user';
-      projectId = process.env.NEXT_PUBLIC_DEFAULT_PROJECT_ID || 'demo-project';
       source = 'env';
     }
 
-    console.log(`[useUserContext] Setting context - userId: ${userId}, projectId: ${projectId}, source: ${source}`);
+    console.log(`[useUserContext] Final values - userId: ${userId} (from ${urlUserId ? 'URL' : propsUserId ? 'props' : 'env'}), projectId: ${projectId} (from ${urlProjectId ? 'URL' : propsProjectId ? 'props' : 'env'}), source: ${source}`);
     setUserContext({ userId, projectId, source });
   }, [propsUserId, propsProjectId]);
 


### PR DESCRIPTION
## Problem

URL parameters (`user_id` and `project_id`) were not being properly used when present. The server logs showed that it was using props/demo content even when URL parameters were provided in the URL.

## Root Cause

The original logic in `useUserContext` required **both** `user_id` and `project_id` URL parameters to be present before it would use URL parameters as the source. If only one URL parameter was provided, it would fall back to using props/demo content.

## Solution

Changed the logic to properly prioritize URL parameters individually:

1. **URL Parameters (Highest Priority)**: If `user_id` or `project_id` are in the URL, they will be used
2. **Component Props (Fallback)**: Used for any missing URL parameters  
3. **Environment Variables (Final Fallback)**: Used if neither URL nor props provide the values

## Changes Made

- ✅ Fixed priority logic to handle individual URL parameters
- ✅ Added enhanced logging to help debug parameter sources
- ✅ Maintains backward compatibility with existing prop and env variable usage
- ✅ Comprehensive testing of all scenarios

## Testing

Tested all scenarios:
- Both URL params present
- Only URL userId present
- Only URL projectId present  
- No URL params, props present
- No URL params, only props userId
- No URL params or props

## Impact

Now when you load the page with URL parameters like `/chat?user_id=12345&project_id=67890`, the server logs will correctly show that it's using the URL parameters instead of falling back to props/demo content.

This ensures the chatbot gets the correct user context for personalized responses.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author